### PR TITLE
Downgrade next to ^12.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,23 @@
 {
-  "name": "@axiomhq/vercel-web-vitals",
-  "version": "0.1.0",
+  "name": "@axiomhq/vercel-next",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@axiomhq/vercel-web-vitals",
-      "version": "0.1.0",
+      "name": "@axiomhq/vercel-next",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^17.0.29",
         "prettier": "2.6.2",
         "typescript": "^4.6.4"
       },
+      "engines": {
+        "node": ">=15"
+      },
       "peerDependencies": {
-        "next": "^12.1.5"
+        "next": "^12.1.4"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/axiomhq/vercel-next#readme",
   "peerDependencies": {
-    "next": "^12.1.5"
+    "next": "^12.1.4"
   },
   "devDependencies": {
     "@types/node": "^17.0.29",


### PR DESCRIPTION
New Next projects on Vercel are created with that version. Before this
commit, people would have to upgrade next before being able to install
this package, even after creating a site.